### PR TITLE
refactor: Move identity store to identities subpath.

### DIFF
--- a/src/identities/identity-provider.js
+++ b/src/identities/identity-provider.js
@@ -4,7 +4,7 @@ import OrbitDBIdentityProvider from './providers/orbitdb.js'
 // import DIDIdentityProvider from './identity-providers/did.js'
 // import EthIdentityProvider from './identity-providers/ethereum.js'
 import KeyStore from '../key-store.js'
-import IdentityStorage from '../storage/identity.js'
+import IdentityStore from './identity-store.js'
 import LRU from 'lru'
 import path from 'path'
 
@@ -140,11 +140,11 @@ class Identities {
 
     let identityStore
     if (options.storage) {
-      identityStore = await IdentityStorage({ storage: options.storage })
+      identityStore = await IdentityStore({ storage: options.storage })
     } else if (options.ipfs) {
-      identityStore = await IdentityStorage({ ipfs: options.ipfs })
+      identityStore = await IdentityStore({ ipfs: options.ipfs })
     } else {
-      identityStore = await IdentityStorage()
+      identityStore = await IdentityStore()
     }
 
     options = Object.assign({}, { type: defaultType, identityStore }, options)

--- a/src/identities/identity-store.js
+++ b/src/identities/identity-store.js
@@ -8,7 +8,7 @@ import * as Block from 'multiformats/block'
 const codec = dagCbor
 const hasher = sha256
 
-const IdentityStorage = async ({ ipfs, storage } = {}) => {
+const IdentityStore = async ({ ipfs, storage } = {}) => {
   storage = storage || (ipfs
     ? await IPFSBlockStorage({ ipfs, pin: true })
     : await MemoryStorage())
@@ -35,4 +35,4 @@ const IdentityStorage = async ({ ipfs, storage } = {}) => {
   }
 }
 
-export default IdentityStorage
+export default IdentityStore

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -1,5 +1,4 @@
 export { default as ComposedStorage } from './composed.js'
-export { default as IdentityStorage } from './identity.js'
 export { default as IPFSBlockStorage } from './ipfs-block.js'
 export { default as LevelStorage } from './level.js'
 export { default as LRUStorage } from './lru.js'


### PR DESCRIPTION
I have named IdentityStorage IdentityStore to fit with our naming convention. The file name is identity-store.js to fit with the naming conventions of other "stores".