### PR TITLE
Add a queue to Database

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "orbit-db-pubsub": "^0.7.0",
         "orbit-db-storage-adapter": "^0.9.0",
         "orbit-db-store": "^5.0.0",
+        "p-queue": "^7.3.4",
         "wherearewe": "^2.0.1"
       },
       "devDependencies": {
@@ -46,8 +47,6 @@
         "ipfsd-ctl": "^13.0.0",
         "key-did-provider-ed25519": "^2.0.1",
         "key-did-resolver": "^2.3.0",
-        "localstorage-down": "^0.6.7",
-        "localstorage-level-migration": "^0.2.0",
         "markdown-toc": "^1.2.0",
         "mkdirp": "^2.1.1",
         "mocha": "^10.2.0",
@@ -4161,15 +4160,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/abstract-leveldown": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.3.tgz",
-      "integrity": "sha512-2XjIA9DFg1Cj2mVm/SmeJ2NIEt/6PRThyHk13ZyVyiZBSYwbEbGMcyt8uEFDlQByYwtBonFOPC0VpxjKVUqJXQ==",
-      "dev": true,
-      "dependencies": {
-        "xtend": "~3.0.0"
-      }
-    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
@@ -4457,12 +4447,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/argsarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/argsarray/-/argsarray-0.0.1.tgz",
-      "integrity": "sha512-u96dg2GcAKtpTrBdDoFIM7PjcBA+6rSP0OR94MOReNRyUECL6MtQt5XXmRr4qrftYaef9+l5hcpO5te7sML1Cg==",
-      "dev": true
     },
     "node_modules/arr-diff": {
       "version": "2.0.0",
@@ -7638,12 +7622,6 @@
         "type": "^1.0.1"
       }
     },
-    "node_modules/d64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
-      "integrity": "sha512-5eNy3WZziVYnrogqgXhcdEmqcDB2IHurTqLcrgssJsfkMVCUoUaZpK6cJjxxvLV2dUm5SuJMNcYfVGoin9UIRw==",
-      "dev": true
-    },
     "node_modules/dag-jose": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-4.0.0.tgz",
@@ -8010,45 +7988,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/deferred-leveldown": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-7.0.0.tgz",
-      "integrity": "sha512-QKN8NtuS3BC6m0B8vAnBls44tX1WXAFATUsJlruyAYbZpysWV3siH6o/i3g9DCHauzodksO60bdj5NazNbjCmg==",
-      "dev": true,
-      "dependencies": {
-        "abstract-leveldown": "^7.2.0",
-        "inherits": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/deferred-leveldown/node_modules/abstract-leveldown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-      "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "catering": "^2.0.0",
-        "is-buffer": "^2.0.5",
-        "level-concat-iterator": "^3.0.0",
-        "level-supports": "^2.0.1",
-        "queue-microtask": "^1.2.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/deferred-leveldown/node_modules/level-supports": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-      "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -12284,12 +12223,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/has-localstorage": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-localstorage/-/has-localstorage-1.0.1.tgz",
-      "integrity": "sha512-0M88QdpTOjOAkVqI7sMGt7hTaVnLppr0sjisFagm+Q9gI3Mmkeqpqu/+RZS4a1doIJ90lmL1WofDMbNB7f+F7Q==",
-      "dev": true
-    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
@@ -12672,16 +12605,6 @@
       "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
       "engines": {
         "node": ">=12.20.0"
-      }
-    },
-    "node_modules/humble-localstorage": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/humble-localstorage/-/humble-localstorage-1.4.2.tgz",
-      "integrity": "sha512-INHaIq55BGlrVCSYw11FxRHQAAQVBO5i1t8kREy778DLMVrgaASCujBwZa2e2+n70sUczlBu5Tjie5iYp1JVeQ==",
-      "dev": true,
-      "dependencies": {
-        "has-localstorage": "^1.0.1",
-        "localstorage-memory": "^1.0.1"
       }
     },
     "node_modules/iconv-lite": {
@@ -15739,93 +15662,6 @@
         "url": "https://opencollective.com/level"
       }
     },
-    "node_modules/level-concat-iterator": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
-      "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
-      "dev": true,
-      "dependencies": {
-        "catering": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/level-errors": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-3.0.1.tgz",
-      "integrity": "sha512-tqTL2DxzPDzpwl0iV5+rBCv65HWbHp6eutluHNcVIftKZlQN//b6GEnZDM2CvGZvzGYMwyPtYppYnydBQd2SMQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/level-iterator-stream": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-5.0.0.tgz",
-      "integrity": "sha512-wnb1+o+CVFUDdiSMR/ZymE2prPs3cjVLlXuDeSq9Zb8o032XrabGEXcTCsBxprAtseO3qvFeGzh6406z9sOTRA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/level-iterator-stream/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/level-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/level-js/-/level-js-6.1.0.tgz",
-      "integrity": "sha512-i7mPtkZm68aewfv0FnIUWvFUFfoyzIvVKnUmuQGrelEkP72vSPTaA1SGneWWoCV5KZJG4wlzbJLp1WxVNGuc6A==",
-      "dev": true,
-      "dependencies": {
-        "abstract-leveldown": "^7.2.0",
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.3",
-        "ltgt": "^2.1.2",
-        "run-parallel-limit": "^1.1.0"
-      }
-    },
-    "node_modules/level-js/node_modules/abstract-leveldown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-      "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "catering": "^2.0.0",
-        "is-buffer": "^2.0.5",
-        "level-concat-iterator": "^3.0.0",
-        "level-supports": "^2.0.1",
-        "queue-microtask": "^1.2.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/level-js/node_modules/level-supports": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-      "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/level-supports": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
@@ -15844,73 +15680,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/leveldown": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.1.tgz",
-      "integrity": "sha512-88c+E+Eizn4CkQOBHwqlCJaTNEjGpaEIikn1S+cINc5E9HEvJ77bqY4JY/HxT5u0caWqsc3P3DcFIKBI1vHt+A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "abstract-leveldown": "^7.2.0",
-        "napi-macros": "~2.0.0",
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
-    "node_modules/leveldown/node_modules/abstract-leveldown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-      "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "catering": "^2.0.0",
-        "is-buffer": "^2.0.5",
-        "level-concat-iterator": "^3.0.0",
-        "level-supports": "^2.0.1",
-        "queue-microtask": "^1.2.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/leveldown/node_modules/level-supports": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-      "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/levelup": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-5.1.1.tgz",
-      "integrity": "sha512-0mFCcHcEebOwsQuk00WJwjLI6oCjbBuEYdh/RaRqhjnyVlzqf41T1NnDtCedumZ56qyIh8euLFDqV1KfzTAVhg==",
-      "dev": true,
-      "dependencies": {
-        "catering": "^2.0.0",
-        "deferred-leveldown": "^7.0.0",
-        "level-errors": "^3.0.1",
-        "level-iterator-stream": "^5.0.0",
-        "level-supports": "^2.0.1",
-        "queue-microtask": "^1.2.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/levelup/node_modules/level-supports": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-      "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/leven": {
@@ -16096,59 +15865,6 @@
       "engines": {
         "node": ">=6.11.5"
       }
-    },
-    "node_modules/localstorage-down": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/localstorage-down/-/localstorage-down-0.6.7.tgz",
-      "integrity": "sha512-FICPps7r0bhe4J4723TVjxkkP/9SgIn95zWC8M6isvibErHHHyrm1gryMXpqyjSd/PaOcdKICvVaJPWW3OWcZQ==",
-      "dev": true,
-      "dependencies": {
-        "abstract-leveldown": "0.12.3",
-        "argsarray": "0.0.1",
-        "buffer-from": "^0.1.1",
-        "d64": "^1.0.0",
-        "humble-localstorage": "^1.4.2",
-        "inherits": "^2.0.1",
-        "tiny-queue": "0.2.0"
-      }
-    },
-    "node_modules/localstorage-down/node_modules/buffer-from": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
-      "dev": true
-    },
-    "node_modules/localstorage-level-migration": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/localstorage-level-migration/-/localstorage-level-migration-0.2.0.tgz",
-      "integrity": "sha512-oyipz7ogIETORPZZaYy0EchMXuc6y2qQjdMRu/TP6zq6lQV07jFNNoH+h5qP2xqcJTXnjbvVTedLZmPHBtWKLw==",
-      "dev": true,
-      "dependencies": {
-        "level": "^8.0.0",
-        "level-js": "^6.1.0",
-        "leveldown": "^6.1.1",
-        "levelup": "^5.1.1",
-        "mkdirp": "^1.0.4",
-        "node-localstorage": "^1.3.1"
-      }
-    },
-    "node_modules/localstorage-level-migration/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/localstorage-memory": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/localstorage-memory/-/localstorage-memory-1.0.3.tgz",
-      "integrity": "sha512-t9P8WB6DcVttbw/W4PIE8HOqum8Qlvx5SjR6oInwR9Uia0EEmyUeBh7S+weKByW+l/f45Bj4L/dgZikGFDM6ng==",
-      "dev": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -16404,12 +16120,6 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
-    },
-    "node_modules/ltgt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
-      "dev": true
     },
     "node_modules/macos-release": {
       "version": "2.5.0",
@@ -18304,18 +18014,6 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
-    "node_modules/node-localstorage": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
-      "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
-      "dev": true,
-      "dependencies": {
-        "write-file-atomic": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/node-pre-gyp": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
@@ -19562,9 +19260,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
-      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
+      "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
       "dependencies": {
         "eventemitter3": "^4.0.7",
         "p-timeout": "^5.0.2"
@@ -22906,15 +22604,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -24285,12 +23974,6 @@
       "engines": {
         "node": ">= 4.5.0"
       }
-    },
-    "node_modules/tiny-queue": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-queue/-/tiny-queue-0.2.0.tgz",
-      "integrity": "sha512-ucfrvjzfbtc+xqmn95DEUtGcDHJHQgZ9IR0mizPOZBkY45reZDCJjafUGVJOGJassjn0MavTyWOCQcG+agpLxw==",
-      "dev": true
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -27368,17 +27051,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "node_modules/write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
-      }
-    },
     "node_modules/wrtc": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/wrtc/-/wrtc-0.4.7.tgz",
@@ -27504,15 +27176,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
       "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w=="
-    },
-    "node_modules/xtend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-      "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -30918,15 +30581,6 @@
         "queue-microtask": "^1.2.3"
       }
     },
-    "abstract-leveldown": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.3.tgz",
-      "integrity": "sha512-2XjIA9DFg1Cj2mVm/SmeJ2NIEt/6PRThyHk13ZyVyiZBSYwbEbGMcyt8uEFDlQByYwtBonFOPC0VpxjKVUqJXQ==",
-      "dev": true,
-      "requires": {
-        "xtend": "~3.0.0"
-      }
-    },
     "abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
@@ -31150,12 +30804,6 @@
           "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
         }
       }
-    },
-    "argsarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/argsarray/-/argsarray-0.0.1.tgz",
-      "integrity": "sha512-u96dg2GcAKtpTrBdDoFIM7PjcBA+6rSP0OR94MOReNRyUECL6MtQt5XXmRr4qrftYaef9+l5hcpO5te7sML1Cg==",
-      "dev": true
     },
     "arr-diff": {
       "version": "2.0.0",
@@ -33761,12 +33409,6 @@
         "type": "^1.0.1"
       }
     },
-    "d64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
-      "integrity": "sha512-5eNy3WZziVYnrogqgXhcdEmqcDB2IHurTqLcrgssJsfkMVCUoUaZpK6cJjxxvLV2dUm5SuJMNcYfVGoin9UIRw==",
-      "dev": true
-    },
     "dag-jose": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-4.0.0.tgz",
@@ -34034,38 +33676,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
-    },
-    "deferred-leveldown": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-7.0.0.tgz",
-      "integrity": "sha512-QKN8NtuS3BC6m0B8vAnBls44tX1WXAFATUsJlruyAYbZpysWV3siH6o/i3g9DCHauzodksO60bdj5NazNbjCmg==",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "^7.2.0",
-        "inherits": "^2.0.3"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-          "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
-          "dev": true,
-          "requires": {
-            "buffer": "^6.0.3",
-            "catering": "^2.0.0",
-            "is-buffer": "^2.0.5",
-            "level-concat-iterator": "^3.0.0",
-            "level-supports": "^2.0.1",
-            "queue-microtask": "^1.2.3"
-          }
-        },
-        "level-supports": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-          "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
-          "dev": true
-        }
-      }
     },
     "define-lazy-prop": {
       "version": "2.0.0",
@@ -37374,12 +36984,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
     },
-    "has-localstorage": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-localstorage/-/has-localstorage-1.0.1.tgz",
-      "integrity": "sha512-0M88QdpTOjOAkVqI7sMGt7hTaVnLppr0sjisFagm+Q9gI3Mmkeqpqu/+RZS4a1doIJ90lmL1WofDMbNB7f+F7Q==",
-      "dev": true
-    },
     "has-property-descriptors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
@@ -37677,16 +37281,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
       "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ=="
-    },
-    "humble-localstorage": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/humble-localstorage/-/humble-localstorage-1.4.2.tgz",
-      "integrity": "sha512-INHaIq55BGlrVCSYw11FxRHQAAQVBO5i1t8kREy778DLMVrgaASCujBwZa2e2+n70sUczlBu5Tjie5iYp1JVeQ==",
-      "dev": true,
-      "requires": {
-        "has-localstorage": "^1.0.1",
-        "localstorage-memory": "^1.0.1"
-      }
     },
     "iconv-lite": {
       "version": "0.6.3",
@@ -40050,79 +39644,6 @@
         "classic-level": "^1.2.0"
       }
     },
-    "level-concat-iterator": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
-      "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
-      "dev": true,
-      "requires": {
-        "catering": "^2.1.0"
-      }
-    },
-    "level-errors": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-3.0.1.tgz",
-      "integrity": "sha512-tqTL2DxzPDzpwl0iV5+rBCv65HWbHp6eutluHNcVIftKZlQN//b6GEnZDM2CvGZvzGYMwyPtYppYnydBQd2SMQ==",
-      "dev": true
-    },
-    "level-iterator-stream": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-5.0.0.tgz",
-      "integrity": "sha512-wnb1+o+CVFUDdiSMR/ZymE2prPs3cjVLlXuDeSq9Zb8o032XrabGEXcTCsBxprAtseO3qvFeGzh6406z9sOTRA==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "level-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/level-js/-/level-js-6.1.0.tgz",
-      "integrity": "sha512-i7mPtkZm68aewfv0FnIUWvFUFfoyzIvVKnUmuQGrelEkP72vSPTaA1SGneWWoCV5KZJG4wlzbJLp1WxVNGuc6A==",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "^7.2.0",
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.3",
-        "ltgt": "^2.1.2",
-        "run-parallel-limit": "^1.1.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-          "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
-          "dev": true,
-          "requires": {
-            "buffer": "^6.0.3",
-            "catering": "^2.0.0",
-            "is-buffer": "^2.0.5",
-            "level-concat-iterator": "^3.0.0",
-            "level-supports": "^2.0.1",
-            "queue-microtask": "^1.2.3"
-          }
-        },
-        "level-supports": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-          "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
-          "dev": true
-        }
-      }
-    },
     "level-supports": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
@@ -40135,61 +39656,6 @@
       "requires": {
         "buffer": "^6.0.3",
         "module-error": "^1.0.1"
-      }
-    },
-    "leveldown": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.1.tgz",
-      "integrity": "sha512-88c+E+Eizn4CkQOBHwqlCJaTNEjGpaEIikn1S+cINc5E9HEvJ77bqY4JY/HxT5u0caWqsc3P3DcFIKBI1vHt+A==",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "^7.2.0",
-        "napi-macros": "~2.0.0",
-        "node-gyp-build": "^4.3.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-          "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
-          "dev": true,
-          "requires": {
-            "buffer": "^6.0.3",
-            "catering": "^2.0.0",
-            "is-buffer": "^2.0.5",
-            "level-concat-iterator": "^3.0.0",
-            "level-supports": "^2.0.1",
-            "queue-microtask": "^1.2.3"
-          }
-        },
-        "level-supports": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-          "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
-          "dev": true
-        }
-      }
-    },
-    "levelup": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-5.1.1.tgz",
-      "integrity": "sha512-0mFCcHcEebOwsQuk00WJwjLI6oCjbBuEYdh/RaRqhjnyVlzqf41T1NnDtCedumZ56qyIh8euLFDqV1KfzTAVhg==",
-      "dev": true,
-      "requires": {
-        "catering": "^2.0.0",
-        "deferred-leveldown": "^7.0.0",
-        "level-errors": "^3.0.1",
-        "level-iterator-stream": "^5.0.0",
-        "level-supports": "^2.0.1",
-        "queue-microtask": "^1.2.3"
-      },
-      "dependencies": {
-        "level-supports": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-          "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
-          "dev": true
-        }
       }
     },
     "leven": {
@@ -40344,57 +39810,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
-      "dev": true
-    },
-    "localstorage-down": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/localstorage-down/-/localstorage-down-0.6.7.tgz",
-      "integrity": "sha512-FICPps7r0bhe4J4723TVjxkkP/9SgIn95zWC8M6isvibErHHHyrm1gryMXpqyjSd/PaOcdKICvVaJPWW3OWcZQ==",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "0.12.3",
-        "argsarray": "0.0.1",
-        "buffer-from": "^0.1.1",
-        "d64": "^1.0.0",
-        "humble-localstorage": "^1.4.2",
-        "inherits": "^2.0.1",
-        "tiny-queue": "0.2.0"
-      },
-      "dependencies": {
-        "buffer-from": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
-          "dev": true
-        }
-      }
-    },
-    "localstorage-level-migration": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/localstorage-level-migration/-/localstorage-level-migration-0.2.0.tgz",
-      "integrity": "sha512-oyipz7ogIETORPZZaYy0EchMXuc6y2qQjdMRu/TP6zq6lQV07jFNNoH+h5qP2xqcJTXnjbvVTedLZmPHBtWKLw==",
-      "dev": true,
-      "requires": {
-        "level": "^8.0.0",
-        "level-js": "^6.1.0",
-        "leveldown": "^6.1.1",
-        "levelup": "^5.1.1",
-        "mkdirp": "^1.0.4",
-        "node-localstorage": "^1.3.1"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        }
-      }
-    },
-    "localstorage-memory": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/localstorage-memory/-/localstorage-memory-1.0.3.tgz",
-      "integrity": "sha512-t9P8WB6DcVttbw/W4PIE8HOqum8Qlvx5SjR6oInwR9Uia0EEmyUeBh7S+weKByW+l/f45Bj4L/dgZikGFDM6ng==",
       "dev": true
     },
     "locate-path": {
@@ -40600,12 +40015,6 @@
       "requires": {
         "yallist": "^3.0.2"
       }
-    },
-    "ltgt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
-      "dev": true
     },
     "macos-release": {
       "version": "2.5.0",
@@ -41932,15 +41341,6 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
       "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
     },
-    "node-localstorage": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
-      "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
-      "dev": true,
-      "requires": {
-        "write-file-atomic": "^1.1.4"
-      }
-    },
     "node-pre-gyp": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
@@ -42905,9 +42305,9 @@
       "integrity": "sha512-/oSZlzK3Chrlrx+LFkiuMzWi2k2aEfIP8V5LandUN3/XRhUlxM1R0Th/xM6SKgjTXnIbZR9GkexTLiar2nKUeg=="
     },
     "p-queue": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
-      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
+      "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
       "requires": {
         "eventemitter3": "^4.0.7",
         "p-timeout": "^5.0.2"
@@ -45471,12 +44871,6 @@
       "integrity": "sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==",
       "dev": true
     },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
-      "dev": true
-    },
     "snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -46538,12 +45932,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
       "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA=="
-    },
-    "tiny-queue": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-queue/-/tiny-queue-0.2.0.tgz",
-      "integrity": "sha512-ucfrvjzfbtc+xqmn95DEUtGcDHJHQgZ9IR0mizPOZBkY45reZDCJjafUGVJOGJassjn0MavTyWOCQcG+agpLxw==",
-      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -48889,17 +48277,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
-      }
-    },
     "wrtc": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/wrtc/-/wrtc-0.4.7.tgz",
@@ -48989,12 +48366,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
       "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w=="
-    },
-    "xtend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-      "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg==",
-      "dev": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "orbit-db-pubsub": "^0.7.0",
     "orbit-db-storage-adapter": "^0.9.0",
     "orbit-db-store": "^5.0.0",
+    "p-queue": "^7.3.4",
     "wherearewe": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds a queue to Database through which addOperation() and sync() calls are queued and processed.

It fixes a race condition where the aforementioned function calls can overlap and cause the oplog to confuse current heads resulting in missing heads.