### PR TITLE
Fix identity storage path and clean up tests

### DIFF
--- a/src/identities/identities.js
+++ b/src/identities/identities.js
@@ -3,11 +3,11 @@ import OrbitDBIdentityProvider from './providers/orbitdb.js'
 // import DIDIdentityProvider from './identity-providers/did.js'
 // import EthIdentityProvider from './identity-providers/ethereum.js'
 import KeyStore, { signMessage, verifyMessage } from '../key-store.js'
-import { LRUStorage, IPFSBlockStorage, MemoryStorage, LevelStorage } from '../storage/index.js'
-import path from 'path'
+import { LRUStorage, IPFSBlockStorage, MemoryStorage } from '../storage/index.js'
+import Path from 'path'
 
 const DefaultProviderType = 'orbitdb'
-const DefaultIdentityKeysPath = path.join('./orbitdb', 'identity', 'identitykeys')
+const DefaultIdentityKeysPath = Path.join('./orbitdb', 'identities')
 
 const supportedTypes = {
   orbitdb: OrbitDBIdentityProvider
@@ -15,13 +15,11 @@ const supportedTypes = {
   // [EthIdentityProvider.type]: EthIdentityProvider
 }
 
-const Identities = async ({ keystore, identityKeysPath, storage, ipfs } = {}) => {
-  keystore = keystore || await KeyStore({ storage: await LevelStorage(identityKeysPath || DefaultIdentityKeysPath), valueEncoding: 'json' })
+const Identities = async ({ keystore, path, storage, ipfs } = {}) => {
+  keystore = keystore || await KeyStore({ path: path || DefaultIdentityKeysPath })
   storage = storage || (ipfs ? await IPFSBlockStorage({ ipfs, pin: true }) : await MemoryStorage())
 
   const verifiedIdentitiesCache = await LRUStorage({ size: 1000 })
-
-  // await keystore.open()
 
   const getIdentity = async (hash) => {
     const bytes = await storage.get(hash)

--- a/test/identities/identities.test.js
+++ b/test/identities/identities.test.js
@@ -1,21 +1,21 @@
 import assert from 'assert'
-import path from 'path'
 import rmrf from 'rimraf'
+import { copy } from 'fs-extra'
 import KeyStore, { signMessage, verifyMessage } from '../../src/key-store.js'
 import Identities, { addIdentityProvider } from '../../src/identities/identities.js'
 import Identity from '../../src/identities/identity.js'
 import testKeysPath from '../fixtures/test-keys-path.js '
-const savedKeysPath = path.resolve('./test/identities/fixtures/savedKeys')
-const identityKeysPath = path.resolve('./test/identities/identityKeys')
+
 const type = 'orbitdb'
+const keysPath = './testkeys'
 
 describe('Identities', function () {
   before(async () => {
-    rmrf.sync(identityKeysPath)
+    await copy(testKeysPath, keysPath)
   })
 
   after(async () => {
-    rmrf.sync(identityKeysPath)
+    await rmrf(keysPath)
   })
 
   describe('Creating Identities', () => {
@@ -31,7 +31,7 @@ describe('Identities', function () {
     })
 
     it('has the correct id', async () => {
-      identities = await Identities({ identityKeysPath })
+      identities = await Identities({ path: keysPath })
       identity = await identities.createIdentity({ id })
       const key = await identities.keystore.getKey(id)
       const externalId = Buffer.from(key.public.marshal()).toString('hex')
@@ -52,7 +52,7 @@ describe('Identities', function () {
     })
 
     it('gets the identity from storage', async () => {
-      identities = await Identities({ identityKeysPath })
+      identities = await Identities({ path: keysPath })
       identity = await identities.createIdentity({ id })
       const result = await identities.getIdentity(identity.hash)
       assert.strictEqual(result.id, identity.id)
@@ -73,7 +73,7 @@ describe('Identities', function () {
     let keystore
 
     before(async () => {
-      keystore = await KeyStore({ path: testKeysPath })
+      keystore = await KeyStore({ path: keysPath })
       identities = await Identities({ keystore })
     })
 
@@ -138,17 +138,16 @@ describe('Identities', function () {
     let savedKeysKeyStore
 
     before(async () => {
-      savedKeysKeyStore = await KeyStore({ path: testKeysPath })
+      savedKeysKeyStore = await KeyStore({ path: keysPath })
 
       identities = await Identities({ keystore: savedKeysKeyStore })
       identity = await identities.createIdentity({ id })
     })
 
     after(async () => {
-      if (identities) {
-        await identities.keystore.close()
+      if (savedKeysKeyStore) {
+        await savedKeysKeyStore.close()
       }
-      rmrf.sync(savedKeysPath)
     })
 
     it('has the correct id', async () => {
@@ -190,7 +189,7 @@ describe('Identities', function () {
     let keystore
 
     before(async () => {
-      keystore = await KeyStore({ path: testKeysPath })
+      keystore = await KeyStore({ path: keysPath })
     })
 
     after(async () => {
@@ -239,7 +238,7 @@ describe('Identities', function () {
     let keystore
 
     before(async () => {
-      keystore = await KeyStore({ path: testKeysPath })
+      keystore = await KeyStore({ path: keysPath })
       identities = await Identities({ keystore })
     })
 
@@ -265,7 +264,7 @@ describe('Identities', function () {
     let keystore
 
     before(async () => {
-      keystore = await KeyStore({ path: testKeysPath })
+      keystore = await KeyStore({ path: keysPath })
       identities = await Identities({ keystore })
       identity = await identities.createIdentity({ id })
     })
@@ -309,7 +308,7 @@ describe('Identities', function () {
     let signature
 
     before(async () => {
-      keystore = await KeyStore({ path: testKeysPath })
+      keystore = await KeyStore({ path: keysPath })
     })
 
     after(async () => {


### PR DESCRIPTION
This PR fixes how Identity storage was setup and changes the argument name from `identityKeysPath` to `path`.

It also cleans up the tests and how fixture keys are used in tests.