### PR TITLE
Don't use secp256k1.publicKeyConvert function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "lru": "^3.1.0",
         "multiformats": "^11.0.1",
         "p-queue": "^7.3.4",
-        "safe-buffer": "^5.2.1",
-        "secp256k1": "^5.0.0"
+        "safe-buffer": "^5.2.1"
       },
       "devDependencies": {
         "cpy-cli": "^4.2.0",
@@ -3441,11 +3440,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
     "node_modules/boxen": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.1.tgz",
@@ -3575,11 +3569,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
     },
     "node_modules/browser-level": {
       "version": "1.0.1",
@@ -5206,20 +5195,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "optional": true
-    },
-    "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -6941,15 +6916,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hashlru": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
@@ -7003,16 +6969,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/home-path": {
@@ -10461,16 +10417,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -10868,11 +10814,6 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.9",
@@ -13012,20 +12953,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/secp256k1": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-5.0.0.tgz",
-      "integrity": "sha512-TKWX8xvoGHrxVdqbYeZM9w+izTF4b9z3NhSaDkdn81btvuh+ivbIMGT/zQvDtTFWhRlThpoz6LEYTr7n8A5GcA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "elliptic": "^6.5.4",
-        "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/semver": {
@@ -18320,11 +18247,6 @@
         "multiformats": "^11.0.0"
       }
     },
-    "bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
     "boxen": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.1.tgz",
@@ -18411,11 +18333,6 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
-    },
-    "brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
     },
     "browser-level": {
       "version": "1.0.1",
@@ -19631,20 +19548,6 @@
           "dev": true,
           "optional": true
         }
-      }
-    },
-    "elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "requires": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "emoji-regex": {
@@ -20933,15 +20836,6 @@
       "integrity": "sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==",
       "dev": true
     },
-    "hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "hashlru": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
@@ -20982,16 +20876,6 @@
       "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
       "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
       "dev": true
-    },
-    "hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "home-path": {
       "version": "1.0.7",
@@ -23511,16 +23395,6 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
-    "minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
-    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -23825,11 +23699,6 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
-    },
-    "node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
     "node-fetch": {
       "version": "2.6.9",
@@ -25402,16 +25271,6 @@
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
         "ajv-keywords": "^3.5.2"
-      }
-    },
-    "secp256k1": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-5.0.0.tgz",
-      "integrity": "sha512-TKWX8xvoGHrxVdqbYeZM9w+izTF4b9z3NhSaDkdn81btvuh+ivbIMGT/zQvDtTFWhRlThpoz6LEYTr7n8A5GcA==",
-      "requires": {
-        "elliptic": "^6.5.4",
-        "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.2.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "lru": "^3.1.0",
     "multiformats": "^11.0.1",
     "p-queue": "^7.3.4",
-    "safe-buffer": "^5.2.1",
-    "secp256k1": "^5.0.0"
+    "safe-buffer": "^5.2.1"
   },
   "devDependencies": {
     "cpy-cli": "^4.2.0",

--- a/test/db/keyvalue-persisted.js
+++ b/test/db/keyvalue-persisted.js
@@ -69,14 +69,14 @@ describe('KeyValuePersisted Database', function () {
   })
 
   it('sets a key/value pair', async () => {
-    const expected = 'zdpuAuXyxGeC6QC2rykxcdZFUoyRromkc9zMHz3LwLHxVVz2x'
+    const expected = 'zdpuAqEDJtUf3Kxg6qZgGv8XFqjtSyyxjF8qbz176Kcro5zwr'
 
     const actual = await db.set('key1', 'value1')
     strictEqual(actual, expected)
   })
 
   it('puts a key/value pair', async () => {
-    const expected = 'zdpuAuXyxGeC6QC2rykxcdZFUoyRromkc9zMHz3LwLHxVVz2x'
+    const expected = 'zdpuAqEDJtUf3Kxg6qZgGv8XFqjtSyyxjF8qbz176Kcro5zwr'
 
     const actual = await db.put('key1', 'value1')
     strictEqual(actual, expected)

--- a/test/db/keyvalue.test.js
+++ b/test/db/keyvalue.test.js
@@ -69,14 +69,14 @@ describe('KeyValue Database', function () {
   })
 
   it('sets a key/value pair', async () => {
-    const expected = 'zdpuAuXyxGeC6QC2rykxcdZFUoyRromkc9zMHz3LwLHxVVz2x'
+    const expected = 'zdpuAqEDJtUf3Kxg6qZgGv8XFqjtSyyxjF8qbz176Kcro5zwr'
 
     const actual = await db.set('key1', 'value1')
     strictEqual(actual, expected)
   })
 
   it('puts a key/value pair', async () => {
-    const expected = 'zdpuAuXyxGeC6QC2rykxcdZFUoyRromkc9zMHz3LwLHxVVz2x'
+    const expected = 'zdpuAqEDJtUf3Kxg6qZgGv8XFqjtSyyxjF8qbz176Kcro5zwr'
 
     const actual = await db.put('key1', 'value1')
     strictEqual(actual, expected)

--- a/test/identities/identities.test.js
+++ b/test/identities/identities.test.js
@@ -129,9 +129,9 @@ describe('Identities', function () {
   describe('create an identity with saved keys', () => {
     const id = 'userX'
 
-    const expectedPublicKey = '0442fa42a69135eade1e37ea520bc8ee9e240efd62cb0edf0516b21258b4eae656241c40da462c95189b1ade83419138ca59845beb90d29b1be8542bde388ca5f9'
+    const expectedPublicKey = '0342fa42a69135eade1e37ea520bc8ee9e240efd62cb0edf0516b21258b4eae656'
     const expectedIdSignature = '3044022068b4bc360d127e39164fbc3b5184f5bd79cc5976286f793d9b38d1f2818e0259022027b875dc8c73635b32db72177b9922038ec4b1eabc8f1fd0919806b0b2519419'
-    const expectedPkIdSignature = '304402206d1aeff3a874b7bd83300219badf68bbcb514e2c60a7b40cec5f78ff2b7ba0f20220085f5f138730603418a0570ba12720f0a46997527bb4a077cd26b545e7811c31'
+    const expectedPkIdSignature = '30440220464cd4a6202dae2d2fb75b47afc7cceafa6b13c310efabbbdaaf38e67f74188b02201bbef8c97b741b4bb9e3e5362edfcd2eb6fe3b93f4e68e5870fcc345a850f366'
 
     let identities
     let identity

--- a/test/key-store.test.js
+++ b/test/key-store.test.js
@@ -184,50 +184,16 @@ describe('KeyStore', () => {
       })
 
       it('gets the public key', async () => {
-        const expected = '04e7247a4c155b63d182a23c70cb6fe8ba2e44bc9e9d62dc45d4c4167ccde95944f13db3c707da2ee0e3fd6ba531caef9f86eb79132023786cd6139ec5ebed4fae'
+        const expected = '02e7247a4c155b63d182a23c70cb6fe8ba2e44bc9e9d62dc45d4c4167ccde95944'
         const publicKey = await keystore.getPublic(key)
         strictEqual(publicKey, expected)
       })
 
       it('gets the public key buffer', async () => {
-        const expected = {
-          type: 'Buffer',
-          data: [
-            4, 231, 36, 122, 76, 21, 91, 99, 209, 130, 162,
-            60, 112, 203, 111, 232, 186, 46, 68, 188, 158, 157,
-            98, 220, 69, 212, 196, 22, 124, 205, 233, 89, 68,
-            241, 61, 179, 199, 7, 218, 46, 224, 227, 253, 107,
-            165, 49, 202, 239, 159, 134, 235, 121, 19, 32, 35,
-            120, 108, 214, 19, 158, 197, 235, 237, 79, 174
-          ]
-        }
+        const expected = '02e7247a4c155b63d182a23c70cb6fe8ba2e44bc9e9d62dc45d4c4167ccde95944'
         const publicKey = await keystore.getPublic(key, { format: 'buffer' })
 
-        deepStrictEqual(publicKey.toJSON(), expected)
-      })
-
-      it('gets the public key when decompress is false', async () => {
-        // const expectedCompressedKey = signingKeys.userA.publicKey
-        const expectedCompressedKey = '02e7247a4c155b63d182a23c70cb6fe8ba2e44bc9e9d62dc45d4c4167ccde95944'
-        const publicKey = await keystore.getPublic(key, { decompress: false })
-        strictEqual(publicKey, expectedCompressedKey)
-      })
-
-      it('gets the public key buffer when decompressed is false', async () => {
-        const expected = {
-          type: 'Buffer',
-          data: [
-            2, 231, 36, 122, 76, 21, 91, 99,
-            209, 130, 162, 60, 112, 203, 111, 232,
-            186, 46, 68, 188, 158, 157, 98, 220,
-            69, 212, 196, 22, 124, 205, 233, 89,
-            68
-          ]
-        }
-
-        const publicKey = await keystore.getPublic(key, { format: 'buffer', decompress: false })
-
-        deepStrictEqual(publicKey.toJSON(), expected)
+        deepStrictEqual(publicKey.toString('hex'), expected)
       })
 
       it('throws an error if no keys are passed', async () => {

--- a/test/oplog/entry.test.js
+++ b/test/oplog/entry.test.js
@@ -30,7 +30,7 @@ describe('Entry', function () {
 
   describe('create', () => {
     it('creates a an empty entry', async () => {
-      const expectedHash = 'zdpuApShn2wbu8aDWJhmzBtLWmoVF5VBbVVtuszMpscmiUgrH'
+      const expectedHash = 'zdpuAyX6yUV5BQMGPaLEvQRa5SDxebEYvQPni6FHyPsRZ7San'
       const entry = await create(testIdentity, 'A', 'hello')
       strictEqual(entry.hash, expectedHash)
       strictEqual(entry.id, 'A')
@@ -43,7 +43,7 @@ describe('Entry', function () {
     })
 
     it('creates a entry with payload', async () => {
-      const expectedHash = 'zdpuApKrG9gBpxSqNRQ1Zq8zkkVTS1GQxYoCkXKtDvuNKv4WB'
+      const expectedHash = 'zdpuAs4V7Wq9smdoHrzYQA46nFfqCF8iWaz98rZJC56bst3kx'
       const payload = 'hello world'
       const entry = await create(testIdentity, 'A', payload)
       strictEqual(entry.hash, expectedHash)

--- a/test/oplog/join.test.js
+++ b/test/oplog/join.test.js
@@ -27,9 +27,9 @@ describe('Log - Join', async function () {
     identities3 = await Identities({ keystore })
     identities4 = await Identities({ keystore })
     testIdentity = await identities1.createIdentity({ id: 'userX' })
-    testIdentity2 = await identities2.createIdentity({ id: 'userA' })
-    testIdentity3 = await identities3.createIdentity({ id: 'userB' })
-    testIdentity4 = await identities4.createIdentity({ id: 'userC' })
+    testIdentity2 = await identities2.createIdentity({ id: 'userB' })
+    testIdentity3 = await identities3.createIdentity({ id: 'userC' })
+    testIdentity4 = await identities4.createIdentity({ id: 'userA' })
   })
 
   after(async () => {
@@ -252,17 +252,18 @@ describe('Log - Join', async function () {
 
   it('joins 4 logs to one', async () => {
     // order determined by identity's publicKey
-    await log1.append('helloA1')
-    await log1.append('helloA2')
+    await log3.append('helloA1')
+    await log3.append('helloA2')
 
-    await log3.append('helloB1')
-    await log3.append('helloB2')
+    await log1.append('helloB1')
+    await log1.append('helloB2')
 
     await log2.append('helloC1')
     await log2.append('helloC2')
 
     await log4.append('helloD1')
     await log4.append('helloD2')
+
     await log1.join(log2)
     await log1.join(log3)
     await log1.join(log4)


### PR DESCRIPTION
This PR changes KeyStore so that we don't use and store the decompressed public key but rather the marshalled one.