### PR TITLE
Increase global maximum event listener limit for tests

### DIFF
--- a/test/config.js
+++ b/test/config.js
@@ -1,3 +1,7 @@
+import { setMaxListeners } from 'events'
+
+setMaxListeners(100)
+
 export default {
   timeout: 30000,
   defaultIpfsConfig: {


### PR DESCRIPTION
This PR increases the limit of event listeners which removes the warning messages from the test run logs.