### PR TITLE
Add Entry index to Log

### DIFF
--- a/benchmarks/log-append.js
+++ b/benchmarks/log-append.js
@@ -37,14 +37,17 @@ const queryLoop = async () => {
   // in case we want to benchmark different storage modules
   const entryStorage = await MemoryStorage()
   const headsStorage = await MemoryStorage()
+  const indexStorage = await MemoryStorage()
   // Test LRUStorage
   // const entryStorage = await LRUStorage()
   // const headsStorage = await LRUStorage()
+  // const indexStorage = await LRUStorage()
   // Test LevelStorage
   // const entryStorage = await LevelStorage({ path: './logA/entries' })
   // const headsStorage = await LevelStorage({ path: './logA/heads' })
+  // const indexStorage = await LevelStorage({ path: './logA/index' })
 
-  log = await Log(testIdentity, { logId: 'A', entryStorage, headsStorage })
+  log = await Log(testIdentity, { logId: 'A', entryStorage, headsStorage, indexStorage })
 
   // Output metrics at 1 second interval
   const interval = setInterval(async () => {

--- a/benchmarks/log-iterator.js
+++ b/benchmarks/log-iterator.js
@@ -15,14 +15,17 @@ import rmrf from 'rimraf'
   // in case we want to benchmark different storage modules
   const entryStorage = await MemoryStorage()
   const headsStorage = await MemoryStorage()
+  const indexStorage = await MemoryStorage()
   // Test LRUStorage
   // const entryStorage = await LRUStorage()
   // const headsStorage = await LRUStorage()
+  // const indexStorage = await LRUStorage()
   // Test LevelStorage
   // const entryStorage = await LevelStorage({ path: './logA/entries' })
   // const headsStorage = await LevelStorage({ path: './logA/heads' })
+  // const indexStorage = await LevelStorage({ path: './logA/index' })
 
-  const log = await Log(testIdentity, { logId: 'A', entryStorage, headsStorage })
+  const log = await Log(testIdentity, { logId: 'A', entryStorage, headsStorage, indexStorage })
 
   const entryCount = 10000
 

--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -48,7 +48,7 @@ const OrbitDB = async ({ ipfs, id, identity, keystore, directory } = {}) => {
   directory = directory || './orbitdb'
   keystore = keystore || await KeyStore({ path: path.join(directory, './keystore') })
   const identities = await Identities({ ipfs, keystore })
-  identity = identity || await identities.createIdentity({ id, keystore })
+  identity = identity || await identities.createIdentity({ id })
 
   const manifestStorage = await ComposedStorage(
     await LRUStorage({ size: 1000 }),

--- a/src/key-store.js
+++ b/src/key-store.js
@@ -21,7 +21,7 @@ const verifySignature = async (signature, publicKey, data) => {
   }
 
   if (!(data instanceof Uint8Array)) {
-    data = typeof data === "string" ? uint8ArrayFromString(data) : new Uint8Array(data)
+    data = typeof data === 'string' ? uint8ArrayFromString(data) : new Uint8Array(data)
   }
 
   const isValid = (key, msg, sig) => key.verify(msg, sig)
@@ -46,8 +46,8 @@ const signMessage = async (key, data) => {
     throw new Error('Given input data was undefined')
   }
 
-	if (!(data instanceof Uint8Array)) {
-    data = typeof data === "string" ? uint8ArrayFromString(data) : new Uint8Array(data)
+  if (!(data instanceof Uint8Array)) {
+    data = typeof data === 'string' ? uint8ArrayFromString(data) : new Uint8Array(data)
   }
 
   return uint8ArrayToString(await key.sign(data), 'base16')

--- a/src/storage/ipfs-block.js
+++ b/src/storage/ipfs-block.js
@@ -20,9 +20,7 @@ const IPFSBlockStorage = async ({ ipfs, timeout, pin } = {}) => {
     })
   }
 
-  const del = async (hash) => {
-    // TODO?
-  }
+  const del = async (hash) => {}
 
   const get = async (hash) => {
     const cid = CID.parse(hash, base58btc)
@@ -33,8 +31,6 @@ const IPFSBlockStorage = async ({ ipfs, timeout, pin } = {}) => {
   }
 
   const iterator = async function * () {}
-
-  // TODO: all()
 
   const merge = async (other) => {}
 
@@ -47,7 +43,6 @@ const IPFSBlockStorage = async ({ ipfs, timeout, pin } = {}) => {
     del,
     get,
     iterator,
-    // TODO: all,
     merge,
     clear,
     close

--- a/src/storage/level.js
+++ b/src/storage/level.js
@@ -34,8 +34,6 @@ const LevelStorage = async ({ path, valueEncoding } = {}) => {
     }
   }
 
-  // TODO: all()
-
   const merge = async (other) => {}
 
   const clear = async () => {
@@ -51,7 +49,6 @@ const LevelStorage = async ({ path, valueEncoding } = {}) => {
     del,
     get,
     iterator,
-    // TODO: all,
     merge,
     clear,
     close

--- a/src/storage/lru.js
+++ b/src/storage/lru.js
@@ -24,8 +24,6 @@ const LRUStorage = async ({ size } = {}) => {
     }
   }
 
-  // TODO: all()
-
   const merge = async (other) => {
     if (other) {
       for await (const [key, value] of other.iterator()) {
@@ -45,7 +43,6 @@ const LRUStorage = async ({ size } = {}) => {
     del,
     get,
     iterator,
-    // TODO: all,
     merge,
     clear,
     close

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -27,8 +27,6 @@ const MemoryStorage = async () => {
     }
   }
 
-  // TODO: all()
-
   const clear = async () => {
     memory = {}
   }
@@ -40,7 +38,6 @@ const MemoryStorage = async () => {
     del,
     get,
     iterator,
-    // TODO: all,
     merge,
     clear,
     close

--- a/test/access-controllers/ipfs-access-controller.test.js
+++ b/test/access-controllers/ipfs-access-controller.test.js
@@ -14,6 +14,7 @@ describe('IPFSAccessController', function () {
   this.timeout(config.timeout)
 
   let ipfs1, ipfs2
+  let keystore1, keystore2
   let identities1, identities2
   let testIdentity1, testIdentity2
 
@@ -22,8 +23,8 @@ describe('IPFSAccessController', function () {
     ipfs2 = await IPFS.create({ ...config.daemon2, repo: './ipfs2' })
     await connectPeers(ipfs1, ipfs2)
 
-    const keystore1 = await Keystore({ path: dbPath1 + '/keys' })
-    const keystore2 = await Keystore({ path: dbPath2 + '/keys' })
+    keystore1 = await Keystore({ path: dbPath1 + '/keys' })
+    keystore2 = await Keystore({ path: dbPath2 + '/keys' })
 
     identities1 = await Identities({ keystore: keystore1 })
     identities2 = await Identities({ keystore: keystore2 })
@@ -39,6 +40,14 @@ describe('IPFSAccessController', function () {
 
     if (ipfs2) {
       await ipfs2.stop()
+    }
+
+    if (keystore1) {
+      await keystore1.close()
+    }
+
+    if (keystore2) {
+      await keystore2.close()
     }
 
     await rmrf('./orbitdb')

--- a/test/config.js
+++ b/test/config.js
@@ -32,6 +32,7 @@ export default {
     }
   },
   daemon1: {
+    silent: true,
     EXPERIMENTAL: {
       pubsub: true
     },
@@ -54,6 +55,7 @@ export default {
     }
   },
   daemon2: {
+    silent: true,
     EXPERIMENTAL: {
       pubsub: true
     },

--- a/test/oplog/join.test.js
+++ b/test/oplog/join.test.js
@@ -426,4 +426,20 @@ describe('Log - Join', async function () {
     strictEqual(values.length, 10)
     deepStrictEqual(values.map((e) => e.payload), expectedData)
   })
+
+  it('has correct heads after joining logs', async () => {
+    const e1 = await log1.append('hello1')
+    await log1.append('hello2')
+    const e3 = await log1.append('hello3')
+
+    await log2.join(log1)
+
+    const heads1 = await log2.heads()
+    deepStrictEqual(heads1, [e3])
+
+    await log2.joinEntry(e1)
+
+    const heads2 = await log2.heads()
+    deepStrictEqual(heads2, [e3])
+  })
 })

--- a/test/oplog/replicate.test.js
+++ b/test/oplog/replicate.test.js
@@ -97,10 +97,10 @@ describe('Log - Replication', function () {
     }
 
     beforeEach(async () => {
-      log1 = await Log(testIdentity1, { logId, storage: storage1 })
-      log2 = await Log(testIdentity2, { logId, storage: storage2 })
-      input1 = await Log(testIdentity1, { logId, storage: storage1 })
-      input2 = await Log(testIdentity2, { logId, storage: storage2 })
+      log1 = await Log(testIdentity1, { logId, entryStorage: storage1 })
+      log2 = await Log(testIdentity2, { logId, entryStorage: storage2 })
+      input1 = await Log(testIdentity1, { logId, entryStorage: storage1 })
+      input2 = await Log(testIdentity2, { logId, entryStorage: storage2 })
       await ipfs1.pubsub.subscribe(logId, handleMessage1)
       await ipfs2.pubsub.subscribe(logId, handleMessage2)
     })
@@ -141,7 +141,7 @@ describe('Log - Replication', function () {
 
       await whileProcessingMessages(config.timeout)
 
-      const result = await Log(testIdentity1, { logId, storage: storage1 })
+      const result = await Log(testIdentity1, { logId, entryStorage: storage1 })
       await result.join(log1)
       await result.join(log2)
 

--- a/test/orbitdb-multiple-databases.test.js
+++ b/test/orbitdb-multiple-databases.test.js
@@ -157,7 +157,15 @@ describe('orbit-db - Multiple Databases', function () {
     }
 
     // Function to check if all databases have been replicated
-    const allReplicated = () => remoteDatabases.every(isReplicated)
+    const allReplicated = async () => {
+      for (const db of remoteDatabases) {
+        const replicated = await isReplicated(db)
+        if (!replicated) {
+          return false
+        }
+      }
+      return true
+    }
 
     console.log('Waiting for replication to finish')
 

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -142,7 +142,7 @@ describe('Sync protocol', function () {
 
       const onSynced = async (bytes) => {
         syncedHead = await Entry.decode(bytes)
-        log2.joinEntry(syncedHead)
+        await log2.joinEntry(syncedHead)
         syncedEventFired = true
       }
 
@@ -349,7 +349,7 @@ describe('Sync protocol', function () {
 
       const onSynced = async (bytes) => {
         syncedHead = await Entry.decode(bytes)
-        if (expectedEntry) {
+        if (expectedEntry && !syncedEventFired) {
           syncedEventFired = expectedEntry.hash === syncedHead.hash
         }
       }

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -122,6 +122,7 @@ describe('Sync protocol', function () {
     let sync1, sync2
     let log1, log2
     let joinEventFired = false
+    let syncedEventFired = false
     let syncedHead
     let expectedEntry
 
@@ -142,6 +143,7 @@ describe('Sync protocol', function () {
       const onSynced = async (bytes) => {
         syncedHead = await Entry.decode(bytes)
         await log2.joinEntry(syncedHead)
+        syncedEventFired = true
       }
 
       const onJoin = (peerId, heads) => {
@@ -155,6 +157,7 @@ describe('Sync protocol', function () {
       sync1.events.on('join', onJoin)
 
       await waitFor(() => joinEventFired, () => true)
+      await waitFor(() => syncedEventFired, () => true)
     })
 
     after(async () => {
@@ -179,13 +182,13 @@ describe('Sync protocol', function () {
       await sync1.add(await log1.append('hello2'))
       await sync1.add(await log1.append('hello3'))
       await sync1.add(await log1.append('hello4'))
-      expectedEntry = await log1.append('hello5')
+      const expected = await log1.append('hello5')
 
-      await sync1.add(expectedEntry)
+      await sync1.add(expected)
 
-      await waitFor(() => Entry.isEqual(expectedEntry, syncedHead), () => true)
+      await waitFor(() => Entry.isEqual(expected, syncedHead), () => true)
 
-      deepStrictEqual(syncedHead, expectedEntry)
+      deepStrictEqual(syncedHead, expected)
 
       deepStrictEqual(await log1.heads(), await log2.heads())
 
@@ -489,8 +492,8 @@ describe('Sync protocol', function () {
     let leavingPeerId
 
     before(async () => {
-      const log1 = await Log(testIdentity1, { logId: 'synclog2' })
-      const log2 = await Log(testIdentity2, { logId: 'synclog2' })
+      const log1 = await Log(testIdentity1, { logId: 'synclog3' })
+      const log2 = await Log(testIdentity2, { logId: 'synclog3' })
 
       const onJoin = (peerId, heads) => {
         joinEventFired = true


### PR DESCRIPTION
This PR adds an entry index to the Log against which we check whether an entry is already known to the log instance.

The PR fixes a bug where old log entries would be considered as new heads. This is captured by the test here https://github.com/orbitdb/orbit-db-nextgen/blob/1a7fe8e2b20c7413e39ddfb0cf522a44695772b9/test/oplog/join.test.js#L430.

The PR also fixes a test in multiple database replication tests.