### PR TITLE
fix: Move top-level await to method.

### DIFF
--- a/conf/webpack.config.js
+++ b/conf/webpack.config.js
@@ -20,9 +20,6 @@ export default (env, argv) => {
       }
     },
     target: 'web',
-    experiments: {
-      topLevelAwait: true
-    },
     externals: {
       fs: '{ existsSync: () => true }',
       mkdirp: '{}'

--- a/conf/webpack.debug.config.js
+++ b/conf/webpack.debug.config.js
@@ -21,9 +21,6 @@ export default (env, argv) => {
     },
     target: 'web',
     devtool: 'source-map',
-    experiments: {
-      topLevelAwait: true
-    },
     externals: {
       fs: '{ existsSync: () => true }',
       mkdirp: '{}'

--- a/conf/webpack.tests.config.js
+++ b/conf/webpack.tests.config.js
@@ -17,9 +17,6 @@ export default (env, argv) => {
     target: 'web',
     mode: 'development',
     devtool: 'source-map',
-    experiments: {
-      topLevelAwait: true
-    },
     externals: {
       fs: '{ existsSync: () => true }',
       'fs-extra': '{ copy: () => {} }',

--- a/src/key-store.js
+++ b/src/key-store.js
@@ -51,9 +51,8 @@ const signMessage = async (key, data) => {
   return Buffer.from(await key.sign(data)).toString('hex')
 }
 
-const verifiedCache = await LRUStorage({ size: 1000 })
-
 const verifyMessage = async (signature, publicKey, data) => {
+  const verifiedCache = await LRUStorage({ size: 1000 })
   const cached = await verifiedCache.get(signature)
 
   let res = false

--- a/src/key-store.js
+++ b/src/key-store.js
@@ -51,8 +51,10 @@ const signMessage = async (key, data) => {
   return Buffer.from(await key.sign(data)).toString('hex')
 }
 
+const verifiedCachePromise = LRUStorage({ size: 1000 })
+
 const verifyMessage = async (signature, publicKey, data) => {
-  const verifiedCache = await LRUStorage({ size: 1000 })
+  const verifiedCache = await verifiedCachePromise
   const cached = await verifiedCache.get(signature)
 
   let res = false


### PR DESCRIPTION
This PR simply moves the (accidental?) top-level await call to the method that it is used in. This makes the library usable in environments where top-level async is unsupported.