### PR TITLE
feat: remove dependence on buffer/safe-buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "lru": "^3.1.0",
         "multiformats": "^11.0.1",
         "p-queue": "^7.3.4",
-        "safe-buffer": "^5.2.1"
+        "safe-buffer": "^5.2.1",
+        "uint8arrays": "^4.0.3"
       },
       "devDependencies": {
         "assert": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "lru": "^3.1.0",
         "multiformats": "^11.0.1",
         "p-queue": "^7.3.4",
-        "safe-buffer": "^5.2.1",
         "uint8arrays": "^4.0.3"
       },
       "devDependencies": {
@@ -14295,6 +14294,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -27986,7 +27986,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "safe-regex-test": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
     "lru": "^3.1.0",
     "multiformats": "^11.0.1",
     "p-queue": "^7.3.4",
-    "safe-buffer": "^5.2.1"
+    "safe-buffer": "^5.2.1",
+    "uint8arrays": "^4.0.3"
   },
   "devDependencies": {
-    "c8": "^7.13.0",
     "assert": "^2.0.0",
     "babel-loader": "^9.1.2",
+    "c8": "^7.13.0",
     "cpy-cli": "^4.2.0",
     "cross-env": "^7.0.3",
     "fs-extra": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "lru": "^3.1.0",
     "multiformats": "^11.0.1",
     "p-queue": "^7.3.4",
-    "safe-buffer": "^5.2.1",
     "uint8arrays": "^4.0.3"
   },
   "devDependencies": {

--- a/src/identities/providers/orbitdb.js
+++ b/src/identities/providers/orbitdb.js
@@ -1,3 +1,4 @@
+import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import IdentityProvider from './interface.js'
 import { signMessage, verifyMessage } from '../../key-store.js'
 
@@ -22,7 +23,7 @@ class OrbitDBIdentityProvider extends IdentityProvider {
       throw new Error('id is required')
     }
     const key = await this._keystore.getKey(id) || await this._keystore.createKey(id)
-    return Buffer.from(key.public.marshal()).toString('hex')
+    return uint8ArrayToString(key.public.marshal(), 'base16')
   }
 
   async signIdentity (data, { id } = {}) {

--- a/test/browser/setup-fixtures.js
+++ b/test/browser/setup-fixtures.js
@@ -1,4 +1,5 @@
 import * as crypto from '@libp2p/crypto'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { Identities, KeyStore } from '../../src/index.js'
 
 const unmarshal = crypto.keys.supportedKeys.secp256k1.unmarshalSecp256k1PrivateKey
@@ -51,10 +52,10 @@ before(async () => {
     ]
 
     for (let user of users) {
-      const privateKey1 = unmarshal(Buffer.from(user.privateKey, 'hex'))
-      const privateKey2 = unmarshal(Buffer.from(user.identity.privateKey, 'hex'))
-      await keystore.addKey(user.id, { privateKey: Buffer.from(privateKey1.marshal()) })
-      await keystore.addKey(user.identity.id, { privateKey: Buffer.from(privateKey2.marshal()) })
+      const privateKey1 = unmarshal(uint8ArrayFromString(user.privateKey, 'base16'))
+      const privateKey2 = unmarshal(uint8ArrayFromString(user.identity.privateKey, 'base16'))
+      await keystore.addKey(user.id, { privateKey: privateKey1.marshal() })
+      await keystore.addKey(user.identity.id, { privateKey: privateKey2.marshal() })
     }
 
     await keystore.close()

--- a/test/identities/identities.test.js
+++ b/test/identities/identities.test.js
@@ -1,6 +1,7 @@
 import assert from 'assert'
 import rmrf from 'rimraf'
 import { copy } from 'fs-extra'
+import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import KeyStore, { signMessage, verifyMessage } from '../../src/key-store.js'
 import Identities, { addIdentityProvider } from '../../src/identities/identities.js'
 import Identity from '../../src/identities/identity.js'
@@ -34,7 +35,7 @@ describe('Identities', function () {
       identities = await Identities({ path: keysPath })
       identity = await identities.createIdentity({ id })
       const key = await identities.keystore.getKey(id)
-      const externalId = Buffer.from(key.public.marshal()).toString('hex')
+      const externalId = uint8ArrayToString(key.public.marshal(), 'base16')
       assert.strictEqual(identity.id, externalId)
     })
   })
@@ -87,7 +88,7 @@ describe('Identities', function () {
       identity = await identities.createIdentity({ id })
       keystore = identities.keystore
       const key = await keystore.getKey(id)
-      const externalId = Buffer.from(key.public.marshal()).toString('hex')
+      const externalId = uint8ArrayToString(key.public.marshal(), 'base16')
       assert.strictEqual(identity.id, externalId)
     })
 
@@ -98,7 +99,7 @@ describe('Identities', function () {
 
     it('has the correct public key', async () => {
       const key = await keystore.getKey(id)
-      const externalId = Buffer.from(key.public.marshal()).toString('hex')
+      const externalId = uint8ArrayToString(key.public.marshal(), 'base16')
       const signingKey = await keystore.getKey(externalId)
       assert.notStrictEqual(signingKey, undefined)
       assert.strictEqual(identity.publicKey, keystore.getPublic(signingKey))
@@ -106,10 +107,10 @@ describe('Identities', function () {
 
     it('has a signature for the id', async () => {
       const key = await keystore.getKey(id)
-      const externalId = Buffer.from(key.public.marshal()).toString('hex')
+      const externalId = uint8ArrayToString(key.public.marshal(), 'base16')
       const signingKey = await keystore.getKey(externalId)
       const idSignature = await signMessage(signingKey, externalId)
-      const publicKey = Buffer.from(signingKey.public.marshal()).toString('hex')
+      const publicKey = uint8ArrayToString(signingKey.public.marshal(), 'base16')
       const verifies = await verifyMessage(idSignature, publicKey, externalId)
       assert.strictEqual(verifies, true)
       assert.strictEqual(identity.signatures.id, idSignature)
@@ -117,7 +118,7 @@ describe('Identities', function () {
 
     it('has a signature for the publicKey', async () => {
       const key = await keystore.getKey(id)
-      const externalId = Buffer.from(key.public.marshal()).toString('hex')
+      const externalId = uint8ArrayToString(key.public.marshal(), 'base16')
       const signingKey = await keystore.getKey(externalId)
       const idSignature = await signMessage(signingKey, externalId)
       const externalKey = await keystore.getKey(id)
@@ -152,7 +153,7 @@ describe('Identities', function () {
 
     it('has the correct id', async () => {
       const key = await savedKeysKeyStore.getKey(id)
-      assert.strictEqual(identity.id, Buffer.from(key.public.marshal()).toString('hex'))
+      assert.strictEqual(identity.id, uint8ArrayToString(key.public.marshal(), 'base16'))
     })
 
     it('has the correct public key', async () => {

--- a/test/key-store.test.js
+++ b/test/key-store.test.js
@@ -1,6 +1,7 @@
 import { strictEqual, deepStrictEqual, deepEqual } from 'assert'
 import * as crypto from '@libp2p/crypto'
 import { Buffer } from 'safe-buffer'
+import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import rmrf from 'rimraf'
 import { copy } from 'fs-extra'
 import KeyStore, { signMessage, verifyMessage } from '../src/key-store.js'
@@ -296,7 +297,7 @@ describe('KeyStore', () => {
         const expected = '02e7247a4c155b63d182a23c70cb6fe8ba2e44bc9e9d62dc45d4c4167ccde95944'
         const publicKey = await keystore.getPublic(key, { format: 'buffer' })
 
-        deepStrictEqual(publicKey.toString('hex'), expected)
+        deepStrictEqual(uint8ArrayToString(publicKey, 'base16'), expected)
       })
 
       it('throws an error if no keys are passed', async () => {

--- a/test/key-store.test.js
+++ b/test/key-store.test.js
@@ -1,7 +1,7 @@
 import { strictEqual, deepStrictEqual, deepEqual } from 'assert'
 import * as crypto from '@libp2p/crypto'
-import { Buffer } from 'safe-buffer'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import rmrf from 'rimraf'
 import { copy } from 'fs-extra'
 import KeyStore, { signMessage, verifyMessage } from '../src/key-store.js'
@@ -151,8 +151,8 @@ describe('KeyStore', () => {
     let privateKeyBuffer, publicKeyBuffer, unmarshalledPrivateKey
 
     before(async () => {
-      privateKeyBuffer = Buffer.from(privateKey, 'hex')
-      publicKeyBuffer = Buffer.from(publicKey, 'hex')
+      privateKeyBuffer = uint8ArrayFromString(privateKey, 'base16')
+      publicKeyBuffer = uint8ArrayFromString(publicKey, 'base16')
       unmarshalledPrivateKey = await unmarshal(privateKeyBuffer)
     })
 


### PR DESCRIPTION
This PR replaces the usage of `Buffers` with `Uint8Array`s. This will make it far easier for users to use this library in the browser.

Buffers are not cross-platform and will need additional tooling to work in the browser. Since nodejs's `Buffer` class is a subclass of `Uint8Array` you can still use buffers in nodejs if preferred.

There is however one breaking change this makes is in [KeyStore.getPublic](https://github.com/orbitdb/orbit-db-nextgen/commit/82fcc830ec97f1a026192a08dec33a6b30fdfc94#diff-310c958944810c3bd9bb06f3f9d50dbb84d07fe0422aa5ee462ad9539cd5f4a2R167-R169) which when passed the option: `format: "buffer"` it will return an `Uint8Array` not an instance of `Buffer`. I have had to change this [test](https://github.com/orbitdb/orbit-db-nextgen/commit/b0483a1b60416106f67c1b093ab7e3c211cb531a) to work with this change.

I have also removed buffer usage from the tests but this is not strictly necessary since `Buffer` is an instance of `Uint8Array` and the test will work regardless of which one is used but to be consistent I switched them over.