### PR TITLE
feat: Remove dependence on path.

### DIFF
--- a/conf/webpack.config.js
+++ b/conf/webpack.config.js
@@ -27,24 +27,11 @@ export default (env, argv) => {
       fs: '{ existsSync: () => true }',
       mkdirp: '{}'
     },
-    plugins: [
-      new webpack.ProvidePlugin({
-        process: 'process/browser',
-        Buffer: ['buffer', 'Buffer']
-      })
-    ],
     resolve: {
       modules: [
         'node_modules',
         path.resolve(__dirname, '../node_modules')
-      ],
-      fallback: {
-        path: require.resolve('path-browserify'),
-        os: false,
-        fs: false,
-        constants: false,
-        stream: false
-      }
+      ]
     },
     resolveLoader: {
       modules: [

--- a/conf/webpack.config.js
+++ b/conf/webpack.config.js
@@ -1,10 +1,7 @@
 import path from 'path'
-import webpack from 'webpack'
 import { fileURLToPath } from 'url'
-import { createRequire } from 'module'
 
 export default (env, argv) => {
-  const require = createRequire(import.meta.url)
   const __filename = fileURLToPath(import.meta.url)
   const __dirname = path.dirname(__filename)
 

--- a/conf/webpack.debug.config.js
+++ b/conf/webpack.debug.config.js
@@ -1,10 +1,7 @@
 import path from 'path'
-import webpack from 'webpack'
 import { fileURLToPath } from 'url'
-import { createRequire } from 'module'
 
 export default (env, argv) => {
-  const require = createRequire(import.meta.url)
   const __filename = fileURLToPath(import.meta.url)
   const __dirname = path.dirname(__filename)
 

--- a/conf/webpack.debug.config.js
+++ b/conf/webpack.debug.config.js
@@ -28,24 +28,11 @@ export default (env, argv) => {
       fs: '{ existsSync: () => true }',
       mkdirp: '{}'
     },
-    plugins: [
-      new webpack.ProvidePlugin({
-        process: 'process/browser',
-        Buffer: ['buffer', 'Buffer']
-      })
-    ],
     resolve: {
       modules: [
         'node_modules',
         path.resolve(__dirname, '../node_modules')
-      ],
-      fallback: {
-        path: require.resolve('path-browserify'),
-        os: false,
-        fs: false,
-        constants: false,
-        stream: false
-      }
+      ]
     },
     resolveLoader: {
       modules: [

--- a/conf/webpack.tests.config.js
+++ b/conf/webpack.tests.config.js
@@ -37,7 +37,8 @@ export default (env, argv) => {
         path.resolve(__dirname, '../node_modules')
       ],
       fallback: {
-        path: require.resolve('path-browserify')
+        path: require.resolve('path-browserify'),
+        process: false
       }
     },
     resolveLoader: {

--- a/conf/webpack.tests.config.js
+++ b/conf/webpack.tests.config.js
@@ -27,6 +27,7 @@ export default (env, argv) => {
     },
     plugins: [
       new webpack.ProvidePlugin({
+        process: 'process/browser',
         Buffer: ['buffer', 'Buffer']
       })
     ],

--- a/conf/webpack.tests.config.js
+++ b/conf/webpack.tests.config.js
@@ -36,7 +36,7 @@ export default (env, argv) => {
         path.resolve(__dirname, '../node_modules')
       ],
       fallback: {
-        path: require.resolve('path-browserify'),
+        path: require.resolve('path-browserify')
       }
     },
     resolveLoader: {

--- a/conf/webpack.tests.config.js
+++ b/conf/webpack.tests.config.js
@@ -27,7 +27,6 @@ export default (env, argv) => {
     },
     plugins: [
       new webpack.ProvidePlugin({
-        process: 'process/browser',
         Buffer: ['buffer', 'Buffer']
       })
     ],
@@ -38,10 +37,6 @@ export default (env, argv) => {
       ],
       fallback: {
         path: require.resolve('path-browserify'),
-        os: false,
-        fs: false,
-        constants: false,
-        stream: false
       }
     },
     resolveLoader: {

--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -9,7 +9,7 @@ import OrbitDBAddress, { isValidAddress } from './address.js'
 import DBManifest from './manifest.js'
 import { createId, isDefined } from './utils/index.js'
 // import Logger from 'logplease'
-import path from 'path'
+import pathJoin from './utils/path-join.js'
 import * as Block from 'multiformats/block'
 import * as dagCbor from '@ipld/dag-cbor'
 import { sha256 } from 'multiformats/hashes/sha2'
@@ -46,7 +46,7 @@ const OrbitDB = async ({ ipfs, id, identity, keystore, directory } = {}) => {
   id = id || await createId()
   const { id: peerId } = await ipfs.id()
   directory = directory || './orbitdb'
-  keystore = keystore || await KeyStore({ path: path.join(directory, './keystore') })
+  keystore = keystore || await KeyStore({ path: pathJoin(directory, './keystore') })
   const identities = await Identities({ ipfs, keystore })
   identity = identity || await identities.createIdentity({ id })
 

--- a/src/address.js
+++ b/src/address.js
@@ -1,6 +1,6 @@
-import * as Path from 'path'
 import { CID } from 'multiformats/cid'
 import { base58btc } from 'multiformats/bases/base58'
+import { posixJoin } from './utils/path-join.js'
 
 const isValidAddress = (address) => {
   address = address.toString()
@@ -45,7 +45,7 @@ const OrbitDBAddress = (address) => {
   const path = address.replace('/orbitdb/', '').replace('\\orbitdb\\', '')
 
   const toString = () => {
-    return (Path.posix || Path).join('/', protocol, '/', path)
+    return posixJoin('/', protocol, path)
   }
 
   return {

--- a/src/database.js
+++ b/src/database.js
@@ -1,8 +1,8 @@
 import { EventEmitter } from 'events'
 import PQueue from 'p-queue'
-import Path from 'path'
 import Sync from './sync.js'
 import { ComposedStorage, LRUStorage, IPFSBlockStorage, LevelStorage } from './storage/index.js'
+import pathJoin from './utils/path-join.js'
 
 const defaultPointerCount = 0
 const defaultCacheSize = 1000
@@ -10,7 +10,7 @@ const defaultCacheSize = 1000
 const Database = async ({ OpLog, ipfs, identity, address, name, accessController, directory, meta, headsStorage, entryStorage, indexStorage, pointerCount, syncAutomatically }) => {
   const { Log, Entry } = OpLog
 
-  directory = Path.join(directory || './orbitdb', `./${address}/`)
+  directory = pathJoin(directory || './orbitdb', `./${address}/`)
   meta = meta || {}
   pointerCount = pointerCount || defaultPointerCount
 
@@ -21,12 +21,12 @@ const Database = async ({ OpLog, ipfs, identity, address, name, accessController
 
   headsStorage = headsStorage || await ComposedStorage(
     await LRUStorage({ size: defaultCacheSize }),
-    await LevelStorage({ path: Path.join(directory, '/log/_heads/') })
+    await LevelStorage({ path: pathJoin(directory, '/log/_heads/') })
   )
 
   indexStorage = indexStorage || await ComposedStorage(
     await LRUStorage({ size: defaultCacheSize }),
-    await LevelStorage({ path: Path.join(directory, '/log/_index/') })
+    await LevelStorage({ path: pathJoin(directory, '/log/_index/') })
   )
 
   const log = await Log(identity, { logId: address, access: accessController, entryStorage, headsStorage, indexStorage })

--- a/src/db/keyvalue-persisted.js
+++ b/src/db/keyvalue-persisted.js
@@ -1,7 +1,7 @@
 import LevelStorage from '../storage/level.js'
 import { KeyValue } from './index.js'
+import pathJoin from '../utils/path-join.js'
 import PQueue from 'p-queue'
-import path from 'path'
 
 const valueEncoding = 'json'
 
@@ -11,7 +11,7 @@ const KeyValuePersisted = async ({ OpLog, Database, ipfs, identity, address, nam
 
   const queue = new PQueue({ concurrency: 1 })
 
-  directory = path.join(directory || './orbitdb', `./${address}/_index/`)
+  directory = pathJoin(directory || './orbitdb', `./${address}/_index/`)
   const index = await LevelStorage({ path: directory, valueEncoding })
 
   let latestOplogHash

--- a/src/identities/identities.js
+++ b/src/identities/identities.js
@@ -4,10 +4,10 @@ import OrbitDBIdentityProvider from './providers/orbitdb.js'
 // import EthIdentityProvider from './identity-providers/ethereum.js'
 import KeyStore, { signMessage, verifyMessage } from '../key-store.js'
 import { LRUStorage, IPFSBlockStorage, MemoryStorage, ComposedStorage } from '../storage/index.js'
-import Path from 'path'
+import pathJoin from '../utils/path-join.js'
 
 const DefaultProviderType = 'orbitdb'
-const DefaultIdentityKeysPath = Path.join('./orbitdb', 'identities')
+const DefaultIdentityKeysPath = pathJoin('./orbitdb', 'identities')
 
 const supportedTypes = {
   orbitdb: OrbitDBIdentityProvider

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -1,5 +1,4 @@
-import path from 'path'
-
+import pathJoin from './utils/path-join.js'
 import * as Block from 'multiformats/block'
 import * as dagCbor from '@ipld/dag-cbor'
 import { sha256 } from 'multiformats/hashes/sha2'
@@ -20,7 +19,7 @@ export default async (storage, name, type, accessControllerAddress, { meta } = {
     {
       name,
       type,
-      accessController: (path.posix || path).join('/ipfs', accessControllerAddress)
+      accessController: pathJoin('/ipfs', accessControllerAddress)
     },
     // meta field is only added to manifest if meta parameter is defined
     meta !== undefined ? { meta } : {}

--- a/src/sync.js
+++ b/src/sync.js
@@ -1,8 +1,8 @@
 import { pipe } from 'it-pipe'
 import PQueue from 'p-queue'
-import Path from 'path'
 import { EventEmitter } from 'events'
 import { TimeoutController } from 'timeout-abort-controller'
+import pathJoin from './utils/path-join.js'
 
 const DefaultTimeout = 30000 // 30 seconds
 
@@ -46,7 +46,7 @@ const Sync = async ({ ipfs, log, events, onSynced, start, timeout }) => {
   if (!log) throw new Error('An instance of log is required.')
 
   const address = log.id
-  const headsSyncAddress = Path.join('/orbitdb/heads/', address)
+  const headsSyncAddress = pathJoin('/orbitdb/heads/', address)
 
   const queue = new PQueue({ concurrency: 1 })
   const peers = new Set()

--- a/src/utils/path-join.js
+++ b/src/utils/path-join.js
@@ -1,13 +1,12 @@
-const posixReg = /((?<=\/)\/+)|(^\.\/)|((?<=\/)\.\/)/g
-const win32Reg = /((?<=\\)\\+)|(^\.\\)|((?<=\\)\.\\)/g
+export const posixJoin = (...paths) => paths
+  .join('/')
+  .replace(/((?<=\/)\/+)|(^\.\/)|((?<=\/)\.\/)/g, '') || '.'
 
-const createJoin = isWin => (...paths) => isWin ?
-  paths.join('\\').replace(/\//g, '\\').replace(win32Reg, '') :
-  paths.join('/').replace(posixReg, '')
+export const win32Join = (...paths) => paths
+  .join('\\')
+  .replace(/\//g, '\\')
+  .replace(/((?<=\\)\\+)|(^\.\\)|((?<=\\)\.\\)/g, '') || '.'
 
-export const join = createJoin(typeof process !== 'undefined' && process?.platform === 'win32')
+export const join = posixJoin
 
-export const posixJoin = createJoin(false)
-export const win32Join = createJoin(true)
-
-export default join
+export default posixJoin

--- a/src/utils/path-join.js
+++ b/src/utils/path-join.js
@@ -1,0 +1,4 @@
+const s = process?.platform === 'win32' ? '\\' : '/'
+const reg = new RegExp(`((?<=\\${s})\\${s}+)|(^\\.\\${s})|((?<=\\${s})\\.\\${s})`, 'g')
+
+export default (...paths) => paths.join(s).replace(reg, '')

--- a/src/utils/path-join.js
+++ b/src/utils/path-join.js
@@ -3,7 +3,7 @@ const win32Reg = /((?<=\\)\\+)|(^\.\\)|((?<=\\)\.\\)/g
 
 const createJoin = isWin => (...paths) => paths.join(isWin ? '\\' : '/').replace(isWin ? win32Reg : posixReg, '')
 
-export const join = createJoin(process?.platform === 'win32')
+export const join = createJoin(typeof process !== 'undefined' && process?.platform === 'win32')
 
 export const posixJoin = createJoin(false)
 export const win32Join = createJoin(true)

--- a/src/utils/path-join.js
+++ b/src/utils/path-join.js
@@ -1,4 +1,11 @@
-const s = process?.platform === 'win32' ? '\\' : '/'
-const reg = new RegExp(`((?<=\\${s})\\${s}+)|(^\\.\\${s})|((?<=\\${s})\\.\\${s})`, 'g')
+const posixReg = /((?<=\/)\/+)|(^\.\/)|((?<=\/)\.\/)/g
+const win32Reg = /((?<=\\)\\+)|(^\.\\)|((?<=\\)\.\\)/g
 
-export default (...paths) => paths.join(s).replace(reg, '')
+const createJoin = isWin => (...paths) => paths.join(isWin ? '\\' : '/').replace(isWin ? win32Reg : posixReg, '')
+
+export const join = createJoin(process?.platform === 'win32')
+
+export const posixJoin = createJoin(false)
+export const win32Join = createJoin(true)
+
+export default join

--- a/src/utils/path-join.js
+++ b/src/utils/path-join.js
@@ -1,7 +1,9 @@
 const posixReg = /((?<=\/)\/+)|(^\.\/)|((?<=\/)\.\/)/g
 const win32Reg = /((?<=\\)\\+)|(^\.\\)|((?<=\\)\.\\)/g
 
-const createJoin = isWin => (...paths) => paths.join(isWin ? '\\' : '/').replace(isWin ? win32Reg : posixReg, '')
+const createJoin = isWin => (...paths) => isWin ?
+  paths.join('\\').replace(/\//g, '\\').replace(win32Reg, '') :
+  paths.join('/').replace(posixReg, '')
 
 export const join = createJoin(typeof process !== 'undefined' && process?.platform === 'win32')
 

--- a/test/path-join.spec.js
+++ b/test/path-join.spec.js
@@ -1,8 +1,6 @@
 import { equal } from 'assert'
 import Path from 'path'
-import { posixJoin, win32Join } from '../src/utils/path-join.js'
-
-const platform = process.platform
+import { join, posixJoin, win32Join } from '../src/utils/path-join.js'
 
 const createTestData = s => [
   [],
@@ -27,13 +25,13 @@ const posixTestData = createTestData('/')
 const win32TestData = createTestData('\\')
 
 describe('Path posix join', () => {
-  it('gives the same results as Path using posix join on posix paths', () => {
+  it('gives the same results as \'path\' using posix join on posix paths', () => {
     for (const data of posixTestData) {
       equal(Path.posix.join(...data), posixJoin(...data))
     }
   })
 
-  it('gives the same results as Path using posix join on win32 paths', () => {
+  it('gives the same results as \'path\' using posix join on win32 paths', () => {
     for (const data of win32TestData) {
       equal(Path.posix.join(...data), posixJoin(...data))
     }
@@ -41,63 +39,27 @@ describe('Path posix join', () => {
 })
 
 describe('Path win32 join', () => {
-  it('gives the same results as Path using win32 join on posix paths', () => {
+  it('gives the same results as \'path\' using win32 join on posix paths', () => {
     for (const data of posixTestData) {
       equal(Path.win32.join(...data), win32Join(...data))
     }
   })
 
-  it('gives the same results as Path using win32 join on win32 paths', () => {
+  it('gives the same results as \'path\' using win32 join on win32 paths', () => {
     for (const data of win32TestData) {
       equal(Path.win32.join(...data), win32Join(...data))
     }
   })
 })
 
-describe('Path join on win32', () => {
-  let join;
-
-  before(async () => {
-    Object.defineProperty(process, 'platform', { value: 'win32', writable: true })
-    join = (await import('../src/utils/path-join.js?win32')).join
-  });
-
-  after(() => {
-    Object.defineProperty(process, 'platform', { value: platform, writable: false })
-  });
-
-  it('gives the same results as Path using posix paths', () => {
+describe('Path join', () => {
+  it('gives the same results as \'path\' on posix paths', () => {
     for (const data of posixTestData) {
       equal(Path.join(...data), join(...data))
     }
   })
 
-  it('gives the same results as Path using win32 paths', () => {
-    for (const data of win32TestData) {
-      equal(Path.join(...data), join(...data))
-    }
-  })
-})
-
-describe('Path join on posix', () => {
-  let join;
-
-  before(async () => {
-    Object.defineProperty(process, 'platform', { value: 'linux', writable: true })
-    join = (await import('../src/utils/path-join.js?linux')).join
-  });
-
-  after(() => {
-    Object.defineProperty(process, 'platform', { value: platform, writable: false })
-  });
-
-  it('gives the same results as Path using posix paths', () => {
-    for (const data of posixTestData) {
-      equal(Path.join(...data), join(...data))
-    }
-  })
-
-  it('gives the same results as Path using win32 paths', () => {
+  it('gives the same results as \'path\' in win32 paths', () => {
     for (const data of win32TestData) {
       equal(Path.join(...data), join(...data))
     }

--- a/test/path-join.spec.js
+++ b/test/path-join.spec.js
@@ -53,13 +53,13 @@ const win32TestData = createTestData('\\')
 })
 
 describe('Path join', () => {
-  it('gives the same results as \'path\' on posix paths', () => {
+  it('gives the same results as \'path\' using join on posix paths', () => {
     for (const data of posixTestData) {
       equal(Path.join(...data), join(...data))
     }
   })
 
-  it('gives the same results as \'path\' in win32 paths', () => {
+  it('gives the same results as \'path\' using join on win32 paths', () => {
     for (const data of win32TestData) {
       equal(Path.join(...data), join(...data))
     }

--- a/test/path-join.spec.js
+++ b/test/path-join.spec.js
@@ -24,7 +24,7 @@ const createTestData = s => [
 const posixTestData = createTestData('/')
 const win32TestData = createTestData('\\')
 
-describe('Path posix join', () => {
+;(Path.posix != null ? describe : describe.skip)('Path posix join', () => {
   it('gives the same results as \'path\' using posix join on posix paths', () => {
     for (const data of posixTestData) {
       equal(Path.posix.join(...data), posixJoin(...data))
@@ -38,7 +38,7 @@ describe('Path posix join', () => {
   })
 })
 
-describe('Path win32 join', () => {
+;(Path.win32 != null ? describe : describe.skip)('Path win32 join', () => {
   it('gives the same results as \'path\' using win32 join on posix paths', () => {
     for (const data of posixTestData) {
       equal(Path.win32.join(...data), win32Join(...data))

--- a/test/path-join.spec.js
+++ b/test/path-join.spec.js
@@ -1,0 +1,99 @@
+import { equal } from 'assert'
+import Path from 'path'
+import { join, posixJoin, win32Join } from '../src/utils/path-join.js'
+
+const platform = process.platform
+
+const createTestData = s => [
+	[s],
+  [s, 'test'],
+  ['test'],
+  ['test', s],
+  [`test${s}`, s],
+  [s, `${s}test`],
+  [`test${s}`, s, `${s}${s}`, `${s}a`],
+  [`test${s}`, '.', `${s}a`],
+  [`test${s}.${s}a`],
+  ['test', s, '.', s]
+]
+
+const posixTestData = createTestData('/')
+const win32TestData = createTestData('\\')
+
+describe('Path posix join', () => {
+  it('gives the same results as Path using posix join on posix paths', () => {
+    for (const data of posixTestData) {
+      equal(Path.posix.join(...data), posixJoin(...data))
+    }
+  })
+
+  it('gives the same results as Path using posix join on win32 paths', () => {
+    for (const data of win32TestData) {
+      equal(Path.posix.join(...data), posixJoin(...data))
+    }
+  })
+})
+
+describe('Path win32 join', () => {
+  it('gives the same results as Path using win32 join on posix paths', () => {
+    for (const data of posixTestData) {
+      equal(Path.win32.join(...data), win32Join(...data))
+    }
+  })
+
+  it('gives the same results as Path using win32 join on win32 paths', () => {
+    for (const data of win32TestData) {
+      equal(Path.win32.join(...data), win32Join(...data))
+    }
+  })
+})
+
+describe('Path join on win32', () => {
+  let join;
+
+  before(async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', writable: true })
+    join = (await import('../src/utils/path-join.js?win32')).join
+  });
+
+  after(() => {
+    Object.defineProperty(process, 'platform', { value: platform, writable: false })
+  });
+
+  it('gives the same results as Path using posix paths', () => {
+    for (const data of posixTestData) {
+      equal(Path.win32.join(...data), join(...data))
+    }
+  })
+
+  it('gives the same results as Path using win32 paths', () => {
+    for (const data of win32TestData) {
+      equal(Path.win32.join(...data), join(...data))
+    }
+  })
+})
+
+describe('Path join on posix', () => {
+  let join;
+
+  before(async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', writable: true })
+    join = (await import('../src/utils/path-join.js?linux')).join
+  });
+
+  after(() => {
+    Object.defineProperty(process, 'platform', { value: platform, writable: false })
+  });
+
+  it('gives the same results as Path using posix paths', () => {
+    for (const data of posixTestData) {
+      equal(Path.posix.join(...data), join(...data))
+    }
+  })
+
+  it('gives the same results as Path using win32 paths', () => {
+    for (const data of win32TestData) {
+      equal(Path.posix.join(...data), join(...data))
+    }
+  })
+})

--- a/test/path-join.spec.js
+++ b/test/path-join.spec.js
@@ -1,11 +1,13 @@
 import { equal } from 'assert'
 import Path from 'path'
-import { join, posixJoin, win32Join } from '../src/utils/path-join.js'
+import { posixJoin, win32Join } from '../src/utils/path-join.js'
 
 const platform = process.platform
 
 const createTestData = s => [
-	[s],
+  [],
+  [''],
+  [s],
   [s, 'test'],
   ['test'],
   ['test', s],
@@ -14,7 +16,11 @@ const createTestData = s => [
   [`test${s}`, s, `${s}${s}`, `${s}a`],
   [`test${s}`, '.', `${s}a`],
   [`test${s}.${s}a`],
-  ['test', s, '.', s]
+  ['test', s, '.', s],
+  ['/test', '\\', 'mixed'],
+  ['\\test', '/', 'mixed'],
+  ['test', '/', 'mixed', '\\', 'data'],
+  ['test', '\\', 'mixed', '/', 'data']
 ]
 
 const posixTestData = createTestData('/')
@@ -62,13 +68,13 @@ describe('Path join on win32', () => {
 
   it('gives the same results as Path using posix paths', () => {
     for (const data of posixTestData) {
-      equal(Path.win32.join(...data), join(...data))
+      equal(Path.join(...data), join(...data))
     }
   })
 
   it('gives the same results as Path using win32 paths', () => {
     for (const data of win32TestData) {
-      equal(Path.win32.join(...data), join(...data))
+      equal(Path.join(...data), join(...data))
     }
   })
 })
@@ -87,13 +93,13 @@ describe('Path join on posix', () => {
 
   it('gives the same results as Path using posix paths', () => {
     for (const data of posixTestData) {
-      equal(Path.posix.join(...data), join(...data))
+      equal(Path.join(...data), join(...data))
     }
   })
 
   it('gives the same results as Path using win32 paths', () => {
     for (const data of win32TestData) {
-      equal(Path.posix.join(...data), join(...data))
+      equal(Path.join(...data), join(...data))
     }
   })
 })


### PR DESCRIPTION
This PR removes the usage of the `path` module and uses a custom `join` utility method in its place since that was the only part of the module that is used.

This will make it easier to use this library in browsers because users won't need to substitute something for the path module (like `path-browserify`) in order to get it to run.