### PR TITLE
refactor: Remove is-defined util.

### DIFF
--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -7,7 +7,7 @@ import { Identities } from './identities/index.js'
 import IPFSAccessController from './access-controllers/ipfs.js'
 import OrbitDBAddress, { isValidAddress } from './address.js'
 import DBManifest from './manifest.js'
-import { createId, isDefined } from './utils/index.js'
+import { createId } from './utils/index.js'
 // import Logger from 'logplease'
 import path from 'path'
 import * as Block from 'multiformats/block'
@@ -39,7 +39,7 @@ const addDatabaseType = (type, store) => {
 const OpLog = { Log, Entry, IPFSBlockStorage, LevelStorage }
 
 const OrbitDB = async ({ ipfs, id, identity, keystore, directory } = {}) => {
-  if (!isDefined(ipfs)) {
+  if (ipfs == null) {
     throw new Error('IPFS instance is a required argument. See https://github.com/orbitdb/orbit-db/blob/master/API.md#createinstance')
   }
 
@@ -97,7 +97,7 @@ const OrbitDB = async ({ ipfs, id, identity, keystore, directory } = {}) => {
       throw new Error(`Unspported database type: '${type}'`)
     }
 
-    const db = await DatabaseModel({ OpLog, Database, ipfs, identity, address: address.toString(), name, accessController, directory, meta, syncAutomatically: isDefined(sync) ? sync : true })
+    const db = await DatabaseModel({ OpLog, Database, ipfs, identity, address: address.toString(), name, accessController, directory, meta, syncAutomatically: sync != null ? sync : true })
 
     db.events.on('close', onDatabaseClosed(address.toString()))
 

--- a/src/identities/identity.js
+++ b/src/identities/identity.js
@@ -2,19 +2,18 @@ import * as Block from 'multiformats/block'
 import * as dagCbor from '@ipld/dag-cbor'
 import { sha256 } from 'multiformats/hashes/sha2'
 import { base58btc } from 'multiformats/bases/base58'
-import isDefined from '../utils/is-defined.js'
 
 const codec = dagCbor
 const hasher = sha256
 const hashStringEncoding = base58btc
 
 const Identity = async ({ id, publicKey, signatures, type, sign, verify } = {}) => {
-  if (!isDefined(id)) throw new Error('Identity id is required')
-  if (!isDefined(publicKey)) throw new Error('Invalid public key')
-  if (!isDefined(signatures)) throw new Error('Signatures object is required')
-  if (!isDefined(signatures.id)) throw new Error('Signature of id is required')
-  if (!isDefined(signatures.publicKey)) throw new Error('Signature of publicKey+id is required')
-  if (!isDefined(type)) throw new Error('Identity type is required')
+  if (id == null) throw new Error('Identity id is required')
+  if (publicKey == null) throw new Error('Invalid public key')
+  if (signatures == null) throw new Error('Signatures object is required')
+  if (signatures.id == null) throw new Error('Signature of id is required')
+  if (signatures.publicKey == null) throw new Error('Signature of publicKey+id is required')
+  if (type == null) throw new Error('Identity type is required')
 
   signatures = Object.assign({}, signatures)
 
@@ -58,14 +57,14 @@ const decodeIdentity = async (bytes) => {
 }
 
 const isIdentity = (identity) => {
-  return isDefined(identity.id) &&
-    isDefined(identity.hash) &&
-    isDefined(identity.bytes) &&
-    isDefined(identity.publicKey) &&
-    isDefined(identity.signatures) &&
-    isDefined(identity.signatures.id) &&
-    isDefined(identity.signatures.publicKey) &&
-    isDefined(identity.type)
+  return identity.id != null &&
+    identity.hash != null &&
+    identity.bytes != null &&
+    identity.publicKey != null &&
+    identity.signatures != null &&
+    identity.signatures.id != null &&
+    identity.signatures.publicKey != null &&
+    identity.type != null
 }
 
 const isEqual = (a, b) => {

--- a/src/oplog/entry.js
+++ b/src/oplog/entry.js
@@ -3,7 +3,6 @@ import * as Block from 'multiformats/block'
 import * as dagCbor from '@ipld/dag-cbor'
 import { sha256 } from 'multiformats/hashes/sha2'
 import { base58btc } from 'multiformats/bases/base58'
-import { isDefined } from '../utils/index.js'
 
 /*
  * @description
@@ -29,10 +28,10 @@ const hashStringEncoding = base58btc
  * // { payload: "hello", next: [], ... }
  */
 const create = async (identity, id, payload, clock = null, next = [], refs = []) => {
-  if (!isDefined(identity)) throw new Error('Identity is required, cannot create entry')
-  if (!isDefined(id)) throw new Error('Entry requires an id')
-  if (!isDefined(payload)) throw new Error('Entry requires a payload')
-  if (!isDefined(next) || !Array.isArray(next)) throw new Error("'next' argument is not an array")
+  if (identity == null) throw new Error('Identity is required, cannot create entry')
+  if (id == null) throw new Error('Entry requires an id')
+  if (payload == null) throw new Error('Entry requires a payload')
+  if (next == null || !Array.isArray(next)) throw new Error("'next' argument is not an array")
 
   clock = clock || new Clock(identity.publicKey)
 

--- a/src/oplog/log.js
+++ b/src/oplog/log.js
@@ -4,7 +4,6 @@ import Clock from './lamport-clock.js'
 import Heads from './heads.js'
 import Sorting from './sorting.js'
 import MemoryStorage from '../storage/memory.js'
-import { isDefined } from '../utils/index.js'
 
 const { LastWriteWins, NoZeroes } = Sorting
 
@@ -49,10 +48,10 @@ const DefaultAccessController = async () => {
  * @return {Log} The log instance
  */
 const Log = async (identity, { logId, logHeads, access, entryStorage, headsStorage, indexStorage, sortFn } = {}) => {
-  if (!isDefined(identity)) {
+  if (identity == null) {
     throw new Error('Identity is required')
   }
-  if (isDefined(logHeads) && !Array.isArray(logHeads)) {
+  if (logHeads != null && !Array.isArray(logHeads)) {
     throw new Error('\'logHeads\' argument must be an array')
   }
   // Set Log's id
@@ -117,7 +116,7 @@ const Log = async (identity, { logId, logHeads, access, entryStorage, headsStora
 
   const has = async (hash) => {
     const entry = await _index.get(hash)
-    return isDefined(entry)
+    return entry != null
   }
 
   /**
@@ -339,10 +338,10 @@ const Log = async (identity, { logId, logHeads, access, entryStorage, headsStora
       lt = nexts
     }
 
-    if (isDefined(lt) && !Array.isArray(lt)) throw new Error('lt must be a string or an array of Entries')
-    if (isDefined(lte) && !Array.isArray(lte)) throw new Error('lte must be a string or an array of Entries')
+    if (lt != null && !Array.isArray(lt)) throw new Error('lt must be a string or an array of Entries')
+    if (lte != null && !Array.isArray(lte)) throw new Error('lte must be a string or an array of Entries')
 
-    const start = (lt || (lte || await heads())).filter(isDefined)
+    const start = (lt || (lte || await heads())).filter(i => i != null)
     const end = (gt || gte) ? await get(gt || gte) : null
 
     const amountToIterate = (end || amount === -1) ? -1 : amount

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,7 +1,5 @@
-import isDefined from './is-defined.js'
 import createId from './create-id.js'
 
 export {
-  isDefined,
   createId
 }

--- a/src/utils/is-defined.js
+++ b/src/utils/is-defined.js
@@ -1,1 +1,0 @@
-export default (arg) => arg !== undefined && arg !== null


### PR DESCRIPTION
This PR remove the `is-defined` utility in favor of a basic null check.

The `is-defined` utility is a one line utility that performs the following check:
```javascript
arg !== undefined && arg !== null
```
Which is [logically the same](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/null#difference_between_null_and_undefined) as:
```javascript
arg != null
```

It seems unnecessary to have this utility since a basic null check is more straight forward and shorter but perhaps there is other reasons for its existence that I am not aware of, such as readability or compatibility?