### PR TITLE
fix: Correct the wrong path join method being used in ensure-ac-address.js.

### DIFF
--- a/src/utils/ensure-ac-address.js
+++ b/src/utils/ensure-ac-address.js
@@ -1,9 +1,9 @@
-import path from 'path'
+import pathJoin from './path-join.js'
 
 // Make sure the given address has '/_access' as the last part
 export default address => {
   const suffix = address.toString().split('/').pop()
   return suffix === '_access'
     ? address
-    : path.join(address, '/_access')
+    : pathJoin(address, '/_access')
 }


### PR DESCRIPTION
This PR replaces the path.join in the new [ensure-ac-address.js](https://github.com/orbitdb/orbit-db-nextgen/blob/main/src/utils/ensure-ac-address.js) util to use the [path-join.js](https://github.com/orbitdb/orbit-db-nextgen/blob/main/src/utils/ensure-ac-address.js) util instead, to match the changes made in #57.